### PR TITLE
Fix initial page load and repo url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,33 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import './App.css';
-import APIClient from './components/APIClient';
-import Button from './components/Button';
+import GitHubContext from './components/GitHubContext';
 import Loading from './components/Loading';
 import Repositories from './components/Repositories';
 import Title from './components/Title/Title';
 import { Repositoyr } from './models/repository';
 
 function App() {
-  const githubClient = useMemo(() => new APIClient('https://api.github.com'), []);
-  const [repositories, setRepositories] = useState<Repositoyr[]>([]);
+  const githubContext = useContext(GitHubContext);
+  const [repositories, setRepositories] = useState<Repositoyr[] | null>(null);
 
-  const getRepositories = useCallback(
-    async () => {
-      setRepositories(await githubClient.get('users/ferreiratiago/repos'));
+  useEffect(
+    () => {
+      (async () => {
+        const repositories = await githubContext.apiClient.get('users/ferreiratiago/repos');
+        setRepositories(repositories);
+      })();
     },
-    [githubClient],
+    [githubContext],
   );
 
   return (
     <div className="App">
       <Title>Query Repositories</Title>
-      <Button onClick={getRepositories}>Get Repos</Button>
       {
-        repositories.length === 0
+        repositories === null
           ? <Loading />
           : <Repositories list={repositories} />
       }
-      <Button onClick={getRepositories}>Refresh</Button>
     </div>
   );
 }

--- a/src/components/GitHubContext.ts
+++ b/src/components/GitHubContext.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import APIClient from './APIClient';
+
+const GitHubContext = React.createContext({
+    apiClient: new APIClient('https://api.github.com'),
+});
+
+export default GitHubContext;

--- a/src/components/RepositoryDetails/RepositoryDetails.tsx
+++ b/src/components/RepositoryDetails/RepositoryDetails.tsx
@@ -23,7 +23,7 @@ export default React.memo(function RepositoryDetails({ content }: { content: Rep
     return (
         <div style={style} onMouseEnter={addHighlight} onMouseLeave={clearHighlight}>
             <p>{content.name}</p>
-            <a href={content.url}>{content.full_name}</a>
+            <a href={content.html_url}>{content.full_name}</a>
         </div>
     );
 });

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -2,5 +2,5 @@ export interface Repositoyr {
     id: number;
     name: string;
     full_name: string;
-    url: string;
+    html_url: string;
 }


### PR DESCRIPTION
## Problem
Currently the **loading has no value**, since there's no initial fetch of the data.

Also, the **repo url is not correct**. It should be the link to the repo instead of the api link.

## Proposed Solution
Fetch the data on page load and should the `Loading` text while the fetch is happening.

Update the repository link to the `html_url`.